### PR TITLE
Add dedicated "How to cite" page with copy-ready citations

### DIFF
--- a/docs/citation.md
+++ b/docs/citation.md
@@ -4,9 +4,7 @@ If you use SquiDBase or data retrieved from it in your research, please cite our
 
 > Wim L Cuypers, Halil Ceylan, Eline Turcksin, Laura Raes, Nicky de Vrij, Johan Michiels, Sandra Coppens, Tessa de Block, Daan Jansen, Kevin K Ariën, Philippe Selhorst, Koen Vercauteren, Julia M Gauglitz, Wout Bittremieux, Kris Laukens. **SquiDBase: a community resource of raw nanopore data from microbes.** *NAR Genomics and Bioinformatics*, 2026, 8(1), lqaf213. [https://doi.org/10.1093/nargab/lqaf213](https://doi.org/10.1093/nargab/lqaf213)
 
-## Citing a specific dataset
-
-When you reuse a particular dataset, also cite its unique SquiDBase (SQB) accession and stable page URL — `https://squidbase.org/submissions/<SQB-ID>`, for example [SQB000004](https://squidbase.org/submissions/SQB000004) — so others can locate the exact data you used.
+To reference a specific dataset, also cite its SquiDBase (SQB) accession, e.g. [SQB000004](https://squidbase.org/submissions/SQB000004).
 
 ## BibTeX
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,68 @@
+# How to cite SquiDBase
+
+If you use SquiDBase or data retrieved from it in your research, please cite our publication:
+
+> Wim L Cuypers, Halil Ceylan, Eline Turcksin, Laura Raes, Nicky de Vrij, Johan Michiels, Sandra Coppens, Tessa de Block, Daan Jansen, Kevin K Ariën, Philippe Selhorst, Koen Vercauteren, Julia M Gauglitz, Wout Bittremieux, Kris Laukens. **SquiDBase: a community resource of raw nanopore data from microbes.** *NAR Genomics and Bioinformatics*, 2026, 8(1), lqaf213. [https://doi.org/10.1093/nargab/lqaf213](https://doi.org/10.1093/nargab/lqaf213)
+
+When you reference a specific dataset, please also cite its unique SquiDBase (SQB) identifier (for example, `SQB000004`) so that others can locate the exact data you used.
+
+## BibTeX
+
+```bibtex
+@article{Cuypers2026SquiDBase,
+  title   = {SquiDBase: a community resource of raw nanopore data from microbes},
+  author  = {Cuypers, Wim L and Ceylan, Halil and Turcksin, Eline and Raes, Laura and de Vrij, Nicky and Michiels, Johan and Coppens, Sandra and de Block, Tessa and Jansen, Daan and Ari{\"e}n, Kevin K and Selhorst, Philippe and Vercauteren, Koen and Gauglitz, Julia M and Bittremieux, Wout and Laukens, Kris},
+  journal = {NAR Genomics and Bioinformatics},
+  year    = {2026},
+  volume  = {8},
+  number  = {1},
+  pages   = {lqaf213},
+  doi     = {10.1093/nargab/lqaf213}
+}
+```
+
+## RIS (EndNote, Zotero, Mendeley)
+
+```ris
+TY  - JOUR
+TI  - SquiDBase: a community resource of raw nanopore data from microbes
+AU  - Cuypers, Wim L
+AU  - Ceylan, Halil
+AU  - Turcksin, Eline
+AU  - Raes, Laura
+AU  - de Vrij, Nicky
+AU  - Michiels, Johan
+AU  - Coppens, Sandra
+AU  - de Block, Tessa
+AU  - Jansen, Daan
+AU  - Ariën, Kevin K
+AU  - Selhorst, Philippe
+AU  - Vercauteren, Koen
+AU  - Gauglitz, Julia M
+AU  - Bittremieux, Wout
+AU  - Laukens, Kris
+JO  - NAR Genomics and Bioinformatics
+PY  - 2026
+VL  - 8
+IS  - 1
+SP  - lqaf213
+DO  - 10.1093/nargab/lqaf213
+UR  - https://doi.org/10.1093/nargab/lqaf213
+ER  -
+```
+
+## Plain text
+
+```text
+Cuypers, W. L., Ceylan, H., Turcksin, E., Raes, L., de Vrij, N., Michiels, J., Coppens, S., de Block, T., Jansen, D., Ariën, K. K., Selhorst, P., Vercauteren, K., Gauglitz, J. M., Bittremieux, W., & Laukens, K. (2026). SquiDBase: a community resource of raw nanopore data from microbes. NAR Genomics and Bioinformatics, 8(1), lqaf213. https://doi.org/10.1093/nargab/lqaf213
+```
+
+## In-text LaTeX
+
+```latex
+SquiDBase~\cite{Cuypers2026SquiDBase}
+```
+
+## Acknowledgements
+
+SquiDBase was developed at the University of Antwerp in the [Laukens lab](https://laukenslab.org/). You can find the team members who contributed to its development, curation, and expansion on the landing page of our website: [SquiDBase Team](https://squidbase.org/).

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -14,10 +14,13 @@ When you reference a specific dataset, please also cite its unique SquiDBase (SQ
   author  = {Cuypers, Wim L and Ceylan, Halil and Turcksin, Eline and Raes, Laura and de Vrij, Nicky and Michiels, Johan and Coppens, Sandra and de Block, Tessa and Jansen, Daan and Ari{\"e}n, Kevin K and Selhorst, Philippe and Vercauteren, Koen and Gauglitz, Julia M and Bittremieux, Wout and Laukens, Kris},
   journal = {NAR Genomics and Bioinformatics},
   year    = {2026},
+  month   = {03},
   volume  = {8},
   number  = {1},
   pages   = {lqaf213},
-  doi     = {10.1093/nargab/lqaf213}
+  issn    = {2631-9268},
+  doi     = {10.1093/nargab/lqaf213},
+  url     = {https://doi.org/10.1093/nargab/lqaf213}
 }
 ```
 
@@ -55,12 +58,6 @@ ER  -
 
 ```text
 Cuypers, W. L., Ceylan, H., Turcksin, E., Raes, L., de Vrij, N., Michiels, J., Coppens, S., de Block, T., Jansen, D., Ariën, K. K., Selhorst, P., Vercauteren, K., Gauglitz, J. M., Bittremieux, W., & Laukens, K. (2026). SquiDBase: a community resource of raw nanopore data from microbes. NAR Genomics and Bioinformatics, 8(1), lqaf213. https://doi.org/10.1093/nargab/lqaf213
-```
-
-## In-text LaTeX
-
-```latex
-SquiDBase~\cite{Cuypers2026SquiDBase}
 ```
 
 ## Acknowledgements

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -4,7 +4,9 @@ If you use SquiDBase or data retrieved from it in your research, please cite our
 
 > Wim L Cuypers, Halil Ceylan, Eline Turcksin, Laura Raes, Nicky de Vrij, Johan Michiels, Sandra Coppens, Tessa de Block, Daan Jansen, Kevin K Ariën, Philippe Selhorst, Koen Vercauteren, Julia M Gauglitz, Wout Bittremieux, Kris Laukens. **SquiDBase: a community resource of raw nanopore data from microbes.** *NAR Genomics and Bioinformatics*, 2026, 8(1), lqaf213. [https://doi.org/10.1093/nargab/lqaf213](https://doi.org/10.1093/nargab/lqaf213)
 
-When you reference a specific dataset, please also cite its unique SquiDBase (SQB) identifier (for example, `SQB000004`) so that others can locate the exact data you used.
+## Citing a specific dataset
+
+When you reuse a particular dataset, also cite its unique SquiDBase (SQB) accession and stable page URL — `https://squidbase.org/submissions/<SQB-ID>`, for example [SQB000004](https://squidbase.org/submissions/SQB000004) — so others can locate the exact data you used.
 
 ## BibTeX
 
@@ -24,41 +26,17 @@ When you reference a specific dataset, please also cite its unique SquiDBase (SQ
 }
 ```
 
-## RIS (EndNote, Zotero, Mendeley)
-
-```ris
-TY  - JOUR
-TI  - SquiDBase: a community resource of raw nanopore data from microbes
-AU  - Cuypers, Wim L
-AU  - Ceylan, Halil
-AU  - Turcksin, Eline
-AU  - Raes, Laura
-AU  - de Vrij, Nicky
-AU  - Michiels, Johan
-AU  - Coppens, Sandra
-AU  - de Block, Tessa
-AU  - Jansen, Daan
-AU  - Ariën, Kevin K
-AU  - Selhorst, Philippe
-AU  - Vercauteren, Koen
-AU  - Gauglitz, Julia M
-AU  - Bittremieux, Wout
-AU  - Laukens, Kris
-JO  - NAR Genomics and Bioinformatics
-PY  - 2026
-VL  - 8
-IS  - 1
-SP  - lqaf213
-DO  - 10.1093/nargab/lqaf213
-UR  - https://doi.org/10.1093/nargab/lqaf213
-ER  -
-```
-
 ## Plain text
 
 ```text
 Cuypers, W. L., Ceylan, H., Turcksin, E., Raes, L., de Vrij, N., Michiels, J., Coppens, S., de Block, T., Jansen, D., Ariën, K. K., Selhorst, P., Vercauteren, K., Gauglitz, J. M., Bittremieux, W., & Laukens, K. (2026). SquiDBase: a community resource of raw nanopore data from microbes. NAR Genomics and Bioinformatics, 8(1), lqaf213. https://doi.org/10.1093/nargab/lqaf213
 ```
+
+## Other formats (RIS, EndNote, RefWorks…)
+
+For RIS, EndNote, RefWorks, and other citation-manager formats, use the **Cite** button on the publisher's article page, which always serves the most up-to-date record:
+
+[Export citation from NAR Genomics and Bioinformatics →](https://academic.oup.com/nargab/article/doi/10.1093/nargab/lqaf213/8417709)
 
 ## Acknowledgements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,6 @@ Please also review our [Terms & Conditions](https://squidbase.org/policy/terms).
 
 # Acknowledgements & citation
 
+SquiDBase was developed at the University of Antwerp in the [Laukens lab](https://laukenslab.org/), and was published in January 2026 in *NAR Genomics and Bioinformatics* (NARGAB): [https://doi.org/10.1093/nargab/lqaf213](https://doi.org/10.1093/nargab/lqaf213).
 
-SquiDBase was developed at the University of Antwerp in the [Laukens lab](https://laukenslab.org/). 
-
-You can find the team members who contributed to the development, curation, and expansion of SquiDBase on the landing page of our website: [SquiDBase Team](https://squidbase.org/).
-
-SquiDBase was published in January 2026 in *NAR Genomics and Bioinformatics* (NARGAB): [https://doi.org/10.1093/nargab/lqaf213](https://doi.org/10.1093/nargab/lqaf213).
+If you use SquiDBase in your research, please see [How to cite](citation.md) for ready-to-copy BibTeX, RIS, and plain-text citations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,17 @@ site_name: SquiDBase Docs
 site_url: https://ominous-couscous-q9v464gpw66h9jw4-8000.app.github.dev/docs/
 repo_url: https://github.com/SquiDBase/docs
 
+nav:
+  - Home: index.md
+  - Retrieving data: retrieving_data.md
+  - Uploading data: uploading_data.md
+  - How to cite: citation.md
+
 theme:
   name: material
   logo: assets/logo.png
+  features:
+    - content.code.copy
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,4 +41,5 @@ extra_css:
   - stylesheets/extra.css
 markdown_extensions:
   - pymdownx.blocks.caption
+  - pymdownx.superfences
   - tables


### PR DESCRIPTION
Add docs/citation.md with BibTeX, RIS, plain-text, and LaTeX citation blocks, enable the Material code-copy button, add explicit nav, and link the index acknowledgements section to the new page.